### PR TITLE
chore: undo Fiber.Pool.stop rename

### DIFF
--- a/fiber/src/fiber.mli
+++ b/fiber/src/fiber.mli
@@ -382,15 +382,15 @@ module Pool : sig
       [Code_error]. *)
   val task : t -> f:(unit -> unit fiber) -> unit fiber
 
-  (** [close pool] stops the pool from receiving new tasks. After this function
+  (** [stop pool] stops the pool from receiving new tasks. After this function
       is called, [task pool ~f] will fail to submit new tasks.
 
       Note that stopping the pool does not prevent already queued tasks from
       running.
 
-      [close pool] subsequent calls to [close] ignored. In other words, this
+      [stop pool] subsequent calls to [stop] ignored. In other words, this
       function is idempotent *)
-  val close : t -> unit fiber
+  val stop : t -> unit fiber
 
   (** [run pool] Runs all tasks submitted to [pool] in parallel. Errors raised
       by such tasks must be caught here.*)

--- a/fiber/src/pool.ml
+++ b/fiber/src/pool.ml
@@ -46,7 +46,7 @@ let task t ~f k =
       t.runner <- Running;
       resume r () k)
 
-let close t k =
+let stop t k =
   match t.status with
   | Closed -> k ()
   | Open -> (

--- a/fiber/test/fiber_tests.ml
+++ b/fiber/test/fiber_tests.ml
@@ -810,7 +810,7 @@ module Pool = Fiber.Pool
 let%expect_test "start & stop pool" =
   Scheduler.run
     (let pool = Pool.create () in
-     Pool.close pool);
+     Pool.stop pool);
   [%expect {| |}]
 
 let%expect_test "run 2 tasks" =
@@ -827,7 +827,7 @@ let%expect_test "run 2 tasks" =
        (fun () -> Pool.run pool)
        (fun () ->
          let* () = tasks () in
-         Pool.close pool));
+         Pool.stop pool));
   [%expect {|
     task 1
     task 2 |}]
@@ -845,7 +845,7 @@ let%expect_test "raise exception" =
            assert (e.exn = Exit);
            print_endline "Caught Exit"
          | _ -> assert false)
-       (fun () -> Pool.close pool));
+       (fun () -> Pool.stop pool));
   [%expect {| Caught Exit |}]
 
 let%expect_test "double run a pool" =
@@ -864,14 +864,14 @@ let%expect_test "double run a pool" =
 
 let%expect_test "run -> stop -> run a pool" =
   (* We shouldn't be able to call [Pool.run] again after we already called
-     [Pool.run] and [Pool.close]. In other words, we can't reuse pools *)
+     [Pool.run] and [Pool.stop]. In other words, we can't reuse pools *)
   (Scheduler.run
   @@
   let pool = Pool.create () in
   let* () =
     Fiber.fork_and_join_unit
       (fun () -> Pool.run pool)
-      (fun () -> Fiber.Pool.task pool ~f:(fun () -> Pool.close pool))
+      (fun () -> Fiber.Pool.task pool ~f:(fun () -> Pool.stop pool))
   in
   Pool.run pool);
   [%expect.unreachable]
@@ -882,7 +882,7 @@ let%expect_test "stop a pool and then run it" =
   (Scheduler.run
   @@
   let pool = Pool.create () in
-  let* () = Pool.close pool in
+  let* () = Pool.stop pool in
   Pool.run pool);
   [%expect {||}]
 
@@ -892,7 +892,7 @@ let%expect_test "pool - weird deadlock" =
   @@
   let pool = Pool.create () in
   let* () = Pool.task pool ~f:Fiber.return in
-  Fiber.fork_and_join_unit (fun () -> Pool.close pool) (fun () -> Pool.run pool)
+  Fiber.fork_and_join_unit (fun () -> Pool.stop pool) (fun () -> Pool.run pool)
   );
   [%expect {||}];
   (* but this does *)
@@ -901,7 +901,7 @@ let%expect_test "pool - weird deadlock" =
   let pool = Pool.create () in
   let* () = Pool.task pool ~f:Fiber.return in
   let* () = Pool.task pool ~f:Fiber.return in
-  Fiber.fork_and_join_unit (fun () -> Pool.close pool) (fun () -> Pool.run pool)
+  Fiber.fork_and_join_unit (fun () -> Pool.stop pool) (fun () -> Pool.run pool)
   );
   [%expect {||}]
 
@@ -910,7 +910,7 @@ let%expect_test "nested run in task" =
   @@
   let pool = Pool.create () in
   let* () = Pool.task pool ~f:(fun () -> Pool.run pool) in
-  Fiber.fork_and_join_unit (fun () -> Pool.close pool) (fun () -> Pool.run pool)
+  Fiber.fork_and_join_unit (fun () -> Pool.stop pool) (fun () -> Pool.run pool)
   );
   [%expect.unreachable]
   [@@expect.uncaught_exn
@@ -928,7 +928,7 @@ let%expect_test "nested tasks" =
               let+ () = Fiber.return () in
               print_endline "inner")
         in
-        Pool.close pool)
+        Pool.stop pool)
   in
   Pool.run pool);
   [%expect {|
@@ -939,7 +939,7 @@ let%expect_test "stopping inside a task" =
   (Scheduler.run
   @@
   let pool = Pool.create () in
-  let* () = Pool.task pool ~f:(fun () -> Pool.close pool) in
+  let* () = Pool.task pool ~f:(fun () -> Pool.stop pool) in
   Pool.run pool);
   [%expect {||}]
 


### PR DESCRIPTION
Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 1f345311-f04f-4176-ae33-04b0075d7383 -->