### PR TITLE
chore: remove Nonempty_list from scheduler

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -26,5 +26,4 @@
  (depends
   (ocaml (>= 4.08))
   lwt
-  stdune
   fiber))

--- a/fiber-lwt.opam
+++ b/fiber-lwt.opam
@@ -10,7 +10,6 @@ depends: [
   "dune" {>= "3.6"}
   "ocaml" {>= "4.08"}
   "lwt"
-  "stdune"
   "fiber"
   "odoc" {with-doc}
 ]

--- a/fiber-lwt/dune
+++ b/fiber-lwt/dune
@@ -1,6 +1,6 @@
 (library
  (public_name fiber-lwt)
  (name fiber_lwt)
- (libraries stdune lwt fiber)
+ (libraries lwt fiber)
  (instrumentation
   (backend bisect_ppx)))

--- a/fiber-lwt/fiber_lwt.ml
+++ b/fiber-lwt/fiber_lwt.ml
@@ -1,5 +1,3 @@
-open Stdune
-
 module Fiber_inside_lwt = struct
   let key = Fiber.Var.create ()
 

--- a/fiber/bench/fiber_bench.ml
+++ b/fiber/bench/fiber_bench.ml
@@ -16,19 +16,13 @@ let%bench_fun "bind" =
 let%bench_fun "create ivar and immediately read" =
  fun () ->
   let ivar = Fiber.Ivar.create () in
-  Fiber.run
-    ~iter:(fun () ->
-      let open Nonempty_list in
-      [ Fiber.Fill (ivar, ()) ])
-    (Fiber.Ivar.read ivar)
+  Fiber.run ~iter:(fun () -> [ Fiber.Fill (ivar, ()) ]) (Fiber.Ivar.read ivar)
 
 let%bench_fun "ivar" =
  fun () ->
   let ivar = ref (Fiber.Ivar.create ()) in
   Fiber.run
-    ~iter:(fun () ->
-      let open Nonempty_list in
-      [ Fiber.Fill (!ivar, ()) ])
+    ~iter:(fun () -> [ Fiber.Fill (!ivar, ()) ])
     (let rec loop = function
        | 0 -> Fiber.return ()
        | n ->

--- a/fiber/src/fiber.mli
+++ b/fiber/src/fiber.mli
@@ -401,7 +401,7 @@ type fill = Fill : 'a Ivar.t * 'a -> fill
 (** [run t ~iter] runs a fiber until it terminates. [iter] is used to implement
     the scheduler, it should block waiting for an event and return at least one
     ivar to fill. *)
-val run : 'a t -> iter:(unit -> fill Nonempty_list.t) -> 'a
+val run : 'a t -> iter:(unit -> fill list) -> 'a
 
 (** Advanced fiber execution *)
 module Scheduler : sig
@@ -419,7 +419,7 @@ module Scheduler : sig
 
   (** Advance a stalled fiber as much as possible by filling a list of ivars.
       Once must call [advance] on a given [stalled] value only once. *)
-  val advance : 'a stalled -> fill Nonempty_list.t -> 'a step
+  val advance : 'a stalled -> fill list -> 'a step
 end
 
 (** {1 Fiber cancellation} *)

--- a/fiber/src/scheduler.ml
+++ b/fiber/src/scheduler.ml
@@ -192,8 +192,7 @@ let repack_step (type a) (module W : Witness with type t = a) (step' : step') =
   | Stalled -> Stalled (module W)
 
 let advance (type a) (module W : Witness with type t = a) fill : a step =
-  fill |> Nonempty_list.to_list |> Jobs.exec_fills |> loop
-  |> repack_step (module W)
+  fill |> Jobs.exec_fills |> loop |> repack_step (module W)
 
 let start (type a) (t : a t) =
   let module W = struct

--- a/fiber/test/fiber_scheduler.ml
+++ b/fiber/test/fiber_scheduler.ml
@@ -1,4 +1,3 @@
-open Stdune
 open Fiber.O
 module Scheduler = Fiber.Scheduler
 
@@ -12,11 +11,7 @@ let%expect_test "test fiber scheduler" =
   (match Scheduler.start (Fiber.of_thunk f) with
   | Done _ -> assert false
   | Stalled s -> (
-    let step =
-      Scheduler.advance s
-        (let open Nonempty_list in
-        [ Fiber.Fill (ivar, ()) ])
-    in
+    let step = Scheduler.advance s [ Fiber.Fill (ivar, ()) ] in
     match step with
     | Done () -> ()
     | Stalled _ -> assert false));


### PR DESCRIPTION
It comes from stdune, and we're trying to remove stdune from the
interface of the library.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: c485575e-e026-4f64-b931-6656ff21ed1e -->