### PR TITLE
feature: replace parallel_iter_set

### DIFF
--- a/fiber/src/fiber.mli
+++ b/fiber/src/fiber.mli
@@ -101,11 +101,7 @@ val all_concurrently_unit : unit t list -> unit t
 (** Iter over a list in parallel. *)
 val parallel_iter : 'a list -> f:('a -> unit t) -> unit t
 
-val parallel_iter_set :
-     (module Set.S with type elt = 'a and type t = 's)
-  -> 's
-  -> f:('a -> unit t)
-  -> unit t
+val parallel_iter_seq : 'a Seq.t -> f:('a -> unit t) -> unit t
 
 val sequential_iter_seq : 'a Seq.t -> f:('a -> unit t) -> unit t
 


### PR DESCRIPTION
Replace parallel_iter_set with parallel_iter_seq. The latter is strictly
more general and is usable with all data structures. Also, it has less
overhead since the first class module indirection has been removed.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 6acf2c6f-c4f3-4148-996c-11563f572f3d -->