### PR TITLE
feature: simplify Make_map_traversals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 - Rename `Fiber.Pool.stop` to `Fiber.Pool.close` (#13, @rgrinberg)
 
+- Remove `Make_map_traversals` and introduce `Make_parallel_map`. The new
+  functor requires a small base API to provide a parallel map on maps and
+  parallel iteration is still available via `parallel_iter_seq`. (#22,
+  @rgrinberg)
+
 # 3.7.0
 
 - Initial release

--- a/fiber/bench/fiber_bench.ml
+++ b/fiber/bench/fiber_bench.ml
@@ -151,17 +151,18 @@ let%bench_fun "Fiber.Pool.run - small" =
   let l = List.init 2 ~f:Fun.id in
   fun () -> pool_run l
 
-module M = Fiber.Make_map_traversals (Int.Map)
+module M = Fiber.Make_parallel_map (Int.Map)
 
 let map =
   List.init 1000 ~f:Fun.id
   |> List.map ~f:(fun i -> (i, i))
   |> Int.Map.of_list_exn
 
-let%bench "Fiber.Map.parallel_iter" =
+let%bench "Fiber.parallel_iter_seq" =
   Fiber.run
     ~iter:(fun () -> assert false)
-    (M.parallel_iter map ~f:(fun _ _ -> Fiber.return ()))
+    (Fiber.parallel_iter_seq (Int.Map.to_seq map) ~f:(fun (_, _) ->
+         Fiber.return ()))
 
 let%bench "Fiber.Map.parallel_map" =
   Fiber.run

--- a/fiber/src/fiber.mli
+++ b/fiber/src/fiber.mli
@@ -105,11 +105,21 @@ val parallel_iter_seq : 'a Seq.t -> f:('a -> unit t) -> unit t
 
 val sequential_iter_seq : 'a Seq.t -> f:('a -> unit t) -> unit t
 
-(** Provide efficient parallel iter/map functions for maps. *)
-module Make_map_traversals (Map : Map.S) : sig
-  val parallel_iter : 'a Map.t -> f:(Map.key -> 'a -> unit t) -> unit t
+(** Provide an efficient parallel map function for maps. *)
+module Make_parallel_map (S : sig
+  type 'a t
 
-  val parallel_map : 'a Map.t -> f:(Map.key -> 'a -> 'b t) -> 'b Map.t t
+  type key
+
+  val empty : _ t
+
+  val is_empty : _ t -> bool
+
+  val to_list : 'a t -> (key * 'a) list
+
+  val mapi : 'a t -> f:(key -> 'a -> 'b) -> 'b t
+end) : sig
+  val parallel_map : 'a S.t -> f:(S.key -> 'a -> 'b t) -> 'b S.t t
 end
 [@@inline always]
 


### PR DESCRIPTION
The new map traversal requires a much smaller subset of the map API and
no longer depends on the map in stdune. Which makes it usable with
whatever map implementation is brought by the user.

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 0406fff9-fb52-4582-9376-3aec818bc4cd -->